### PR TITLE
Retro-terminal theme with matrix rain landing

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="{{ or site.Language.LanguageCode site.Language.Lang }}"
+  dir="{{ or site.Language.LanguageDirection `ltr` }}">
+
+<head>
+  {{ partial "head.html" . }}
+</head>
+
+<body>
+  <div class="crt-container container mx-auto px-4" style="max-width: 900px;">
+    {{ block "main" . }}{{ end }}
+  </div>
+  {{ partialCached "head/js.html" . }}
+  {{ partial "third_party_js.html" . }}
+</body>
+
+</html>

--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -1,31 +1,133 @@
 {{ define "main" }}
-    <div class="flex flex-col h-[calc(100dvh)]">
-      {{ partial "header.html" . }}
-      <div class="flex flex-col justify-center items-center gap-4 flex-grow">
-        <div class="flex flex-col justify-center items-center gap-4">
-          <!-- Name of Website -->
-          <div class="flex flex-col gap-4 items-center justify-center">
-            <h1 class="font-bold text-5xl hover:text-sky-400 max-sm:text-4xl">
-              <a href="{{ .Site.BaseURL }}" class="whitespace-nowrap">
-                Patrick Nelson
-              </a>
-            </h1>
-            <p>Automation, Optimization, Innovation.</p>
-          </div>
-          <!-- Navigation for Big Screens -->
-          <div>
-            <ul class="flex flex-row justify-center items-center gap-6 text-xl max-sm:hidden visible">
-              {{ partial "home_menu.html" . }}
-            </ul>
-          </div>
-          <!-- Social -->
-          <div class="flex flex-row gap-6 p-4 border">
-            {{ partial "social.html" . }}
-          </div>
-        </div>
-        
-        {{ partial "footer_bottom.html" . }}
-        
+
+  <!-- Matrix binary rain canvas (plays once, then removed) -->
+  <canvas id="matrix-rain" class="matrix-canvas"></canvas>
+
+  <!-- Main content (fades in after rain) -->
+  <main id="main-content" class="home-screen" style="opacity: 0;">
+
+    <div class="home-header">
+      <h1 class="pixel-font site-title">PATRICK NELSON</h1>
+      <p class="tagline">
+        Teaching machines to keep the lights on.<span class="cursor"></span>
+      </p>
+    </div>
+
+    <div class="home-grid">
+      <div class="grid-item">
+        <span class="prompt">&gt;</span>
+        <a href="/about.html">about.exe</a>
+        <span class="desc">// who I am & where I'm headed</span>
       </div>
-  </div>
+      <div class="grid-item">
+        <span class="prompt">&gt;</span>
+        <a href="/resume/">resume.dat</a>
+        <span class="desc">// experience, skills, education</span>
+      </div>
+      <div class="grid-item">
+        <span class="prompt">&gt;</span>
+        <a href="/blog/">blog.log</a>
+        <span class="desc">// dispatches from the terminal</span>
+      </div>
+    </div>
+
+    <div class="social-bar">
+      <span class="prompt">links$</span>
+      <a href="https://github.com/pat-nel87" target="_blank">[github]</a>
+      <a href="https://www.linkedin.com/in/patrick-nelson-1b41561b6/" target="_blank">[linkedin]</a>
+    </div>
+
+    <p class="home-footer-text">
+      <span class="muted">sys:</span> Senior DevOps Engineer | AI-Augmented SRE
+      <br>
+      <span class="muted">loc:</span> Massachusetts
+      <br>
+      <span class="muted">stack:</span> Go / Python / Azure / Kubernetes / Terraform
+    </p>
+
+  </main>
+
+<script>
+(function() {
+  const canvas = document.getElementById('matrix-rain');
+  const main = document.getElementById('main-content');
+
+  // Skip animation on repeat visits within the same session
+  if (sessionStorage.getItem('introDone')) {
+    canvas.remove();
+    main.style.opacity = '1';
+    return;
+  }
+
+  const ctx = canvas.getContext('2d');
+  let w, h, columns, drops;
+  const fontSize = 14;
+  const chars = '01';
+
+  function resize() {
+    w = canvas.width = window.innerWidth;
+    h = canvas.height = window.innerHeight;
+    columns = Math.floor(w / fontSize);
+    drops = Array.from({ length: columns }, () =>
+      Math.random() * -50 | 0
+    );
+  }
+
+  resize();
+  window.addEventListener('resize', resize);
+
+  function draw() {
+    ctx.fillStyle = 'rgba(10, 10, 10, 0.06)';
+    ctx.fillRect(0, 0, w, h);
+
+    ctx.font = fontSize + 'px "IBM Plex Mono", monospace';
+
+    for (let i = 0; i < columns; i++) {
+      const char = chars[Math.random() * chars.length | 0];
+      const x = i * fontSize;
+      const y = drops[i] * fontSize;
+
+      if (Math.random() > 0.3) {
+        ctx.fillStyle = '#33ff33';
+      } else {
+        ctx.fillStyle = '#1a9e1a';
+      }
+
+      ctx.fillText(char, x, y);
+
+      if (y > h && Math.random() > 0.98) {
+        drops[i] = 0;
+      }
+      drops[i]++;
+    }
+  }
+
+  // Run rain animation
+  const interval = setInterval(draw, 45);
+
+  // After ~2.5 seconds, fade out rain and fade in content
+  setTimeout(() => {
+    clearInterval(interval);
+
+    canvas.style.transition = 'opacity 0.8s ease-out';
+    canvas.style.opacity = '0';
+
+    setTimeout(() => {
+      canvas.remove();
+      main.style.transition = 'opacity 1s ease-in';
+      main.style.opacity = '1';
+      sessionStorage.setItem('introDone', '1');
+    }, 800);
+  }, 2500);
+
+  // Click to skip
+  canvas.addEventListener('click', () => {
+    clearInterval(interval);
+    canvas.remove();
+    main.style.opacity = '1';
+    sessionStorage.setItem('introDone', '1');
+  });
+})();
+</script>
+
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,10 +2,19 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{{ .Description }}">
 <!-- Geo tags -->
-<meta name="ICBM" content="19.0760, 72.8777">
-<meta name="geo.position" content="19.0760;72.8777">
-<meta name="geo.region" content="US-NY">
-<meta name="geo.placename" content="New York">
+<meta name="ICBM" content="42.3601, -71.0589">
+<meta name="geo.position" content="42.3601;-71.0589">
+<meta name="geo.region" content="US-MA">
+<meta name="geo.placename" content="Massachusetts">
 <title>{{ if .IsHome }}{{ site.Title }}{{ else }}{{ printf "%s | %s" .Title site.Title }}{{ end }}</title>
 
+<!-- Retro Terminal Fonts -->
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;700&family=Press+Start+2P&display=swap" rel="stylesheet">
+
+<!-- Theme CSS (from terminal theme) -->
 {{ partialCached "head/css.html" . }}
+
+<!-- Retro Terminal Custom CSS -->
+<link rel="stylesheet" href="/css/custom.css">

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,348 @@
+/* ============================================
+   RETRO-TERMINAL THEME — patricknelson-devops.net
+   ============================================ */
+
+/* --- Color Palette --- */
+:root {
+  --terminal-bg: #0a0a0a;
+  --terminal-green: #33ff33;
+  --terminal-green-dim: #1a9e1a;
+  --terminal-green-bright: #66ff66;
+  --terminal-amber: #ffb000;
+  --terminal-cyan: #00e5ff;
+  --terminal-text: #c0ffc0;
+  --terminal-muted: #2a6e2a;
+  --terminal-border: #1a5c1a;
+  --terminal-link: #33ff33;
+  --terminal-link-hover: #66ff66;
+  --terminal-selection-bg: #1a5c1a;
+  --terminal-selection-text: #66ff66;
+}
+
+/* --- Base Reset & Body --- */
+body {
+  background-color: var(--terminal-bg) !important;
+  color: var(--terminal-text) !important;
+  font-family: 'IBM Plex Mono', 'Fira Code', 'Courier New', monospace !important;
+  line-height: 1.7;
+}
+
+::selection {
+  background: var(--terminal-selection-bg);
+  color: var(--terminal-selection-text);
+}
+
+/* --- Links --- */
+a {
+  color: var(--terminal-link) !important;
+  text-decoration: none !important;
+  border-bottom: 1px dashed var(--terminal-muted);
+  transition: all 0.2s ease;
+}
+
+a:hover {
+  color: var(--terminal-link-hover) !important;
+  border-bottom-style: solid;
+  text-shadow: 0 0 8px var(--terminal-green);
+}
+
+/* --- Headings --- */
+h1, h2, h3, h4, h5, h6 {
+  color: var(--terminal-text) !important;
+  text-shadow:
+    0 0 4px rgba(51, 255, 51, 0.2);
+}
+
+h1 {
+  font-family: 'Press Start 2P', cursive !important;
+  font-size: 1.2rem !important;
+  line-height: 1.8 !important;
+}
+
+h2 {
+  font-family: 'Press Start 2P', cursive !important;
+  font-size: 0.9rem !important;
+  line-height: 1.8 !important;
+}
+
+h3 {
+  font-family: 'IBM Plex Mono', monospace !important;
+  font-size: 1rem !important;
+  font-weight: 700 !important;
+}
+
+/* --- Pixel Font Utility --- */
+.pixel-font {
+  font-family: 'Press Start 2P', cursive;
+  letter-spacing: 1px;
+}
+
+/* --- CRT Scanline Overlay --- */
+body::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  background: repeating-linear-gradient(
+    0deg,
+    rgba(0, 0, 0, 0.15) 0px,
+    rgba(0, 0, 0, 0.15) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+
+/* --- Subtle Screen Flicker --- */
+@keyframes flicker {
+  0%   { opacity: 0.97; }
+  50%  { opacity: 1.00; }
+  100% { opacity: 0.98; }
+}
+
+.crt-container {
+  animation: flicker 4s infinite;
+}
+
+/* --- Blinking Cursor --- */
+@keyframes blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0; }
+}
+
+.cursor {
+  display: inline-block;
+  width: 0.6em;
+  height: 1.1em;
+  background: var(--terminal-green);
+  animation: blink 1s step-end infinite;
+  vertical-align: text-bottom;
+  margin-left: 2px;
+}
+
+/* --- Container Override --- */
+.container {
+  background-color: var(--terminal-bg) !important;
+}
+
+/* --- Navigation Override --- */
+nav a, .menu a, header a {
+  color: var(--terminal-green) !important;
+  border-bottom: none !important;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+nav a:hover, .menu a:hover, header a:hover {
+  color: var(--terminal-amber) !important;
+  text-shadow: 0 0 8px var(--terminal-amber);
+}
+
+/* --- Code Blocks --- */
+pre, code {
+  background-color: #111 !important;
+  color: var(--terminal-green) !important;
+  border: 1px solid var(--terminal-border) !important;
+  font-family: 'IBM Plex Mono', monospace !important;
+}
+
+pre {
+  padding: 1rem !important;
+  border-radius: 0 !important;
+}
+
+/* --- Borders & Dividers --- */
+hr {
+  border-color: var(--terminal-border);
+}
+
+/* --- Lists --- */
+ul, ol {
+  color: var(--terminal-text);
+}
+
+li::marker {
+  color: var(--terminal-green-dim);
+}
+
+/* --- Blockquotes --- */
+blockquote {
+  border-left: 3px solid var(--terminal-green-dim);
+  color: var(--terminal-muted);
+  padding-left: 1rem;
+}
+
+/* --- Strong / Bold --- */
+strong, b {
+  color: var(--terminal-green-bright);
+}
+
+/* --- Emphasis / Italic --- */
+em, i {
+  color: var(--terminal-amber);
+}
+
+/* ============================================
+   HOME PAGE
+   ============================================ */
+
+/* Matrix canvas */
+.matrix-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 100;
+  background: #0a0a0a;
+  cursor: pointer;
+}
+
+/* Home page layout */
+.home-screen {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 2rem;
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.site-title {
+  font-size: 1.4rem !important;
+  margin-bottom: 0.5rem;
+  text-shadow: 0 0 10px var(--terminal-green), 0 0 20px rgba(51,255,51,0.2);
+}
+
+.tagline {
+  font-family: 'IBM Plex Mono', monospace;
+  color: var(--terminal-amber);
+  font-size: 1rem;
+  margin-bottom: 2rem;
+}
+
+.home-grid {
+  margin: 1.5rem 0;
+}
+
+.grid-item {
+  padding: 0.4rem 0;
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.grid-item .prompt {
+  color: var(--terminal-green);
+  margin-right: 0.5rem;
+}
+
+.grid-item .desc {
+  color: var(--terminal-muted);
+  font-size: 0.8rem;
+  margin-left: 0.5rem;
+}
+
+.social-bar {
+  margin: 1.5rem 0;
+  padding: 0.8rem 0;
+  border-top: 1px solid var(--terminal-border);
+  border-bottom: 1px solid var(--terminal-border);
+}
+
+.social-bar .prompt {
+  color: var(--terminal-green-dim);
+  margin-right: 0.75rem;
+}
+
+.social-bar a {
+  margin-right: 1rem;
+  font-size: 0.85rem;
+}
+
+.home-footer-text {
+  margin-top: 1.5rem;
+  font-size: 0.8rem;
+  line-height: 1.8;
+  color: var(--terminal-text);
+}
+
+.muted {
+  color: var(--terminal-muted);
+}
+
+/* ============================================
+   RESUME PAGE
+   ============================================ */
+
+.resume-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.resume-header {
+  font-family: 'IBM Plex Mono', monospace;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--terminal-border);
+  color: var(--terminal-green);
+}
+
+.resume-header .pipe {
+  color: var(--terminal-muted);
+  margin: 0 0.5rem;
+}
+
+.download-link {
+  color: var(--terminal-amber) !important;
+}
+
+.resume-content h2 {
+  font-family: 'Press Start 2P', cursive !important;
+  font-size: 1rem !important;
+  color: var(--terminal-green-bright) !important;
+  margin-top: 0;
+}
+
+.resume-content h3 {
+  color: var(--terminal-amber) !important;
+  border-bottom: 1px dashed var(--terminal-border);
+  padding-bottom: 0.3rem;
+}
+
+.resume-content h4 {
+  color: var(--terminal-green) !important;
+  margin-bottom: 0.25rem;
+}
+
+.resume-content h4 + p em {
+  color: var(--terminal-muted) !important;
+  font-style: normal;
+}
+
+.terminal-output li {
+  position: relative;
+  padding-left: 1.2rem;
+  margin-bottom: 0.5rem;
+}
+
+.terminal-output li::before {
+  content: ">";
+  position: absolute;
+  left: 0;
+  color: var(--terminal-green-dim);
+}
+
+/* ============================================
+   RESPONSIVE
+   ============================================ */
+
+@media (max-width: 600px) {
+  .site-title { font-size: 0.9rem !important; }
+  .tagline { font-size: 0.85rem; }
+  .grid-item .desc { display: block; margin-left: 1.5rem; }
+  h1 { font-size: 0.9rem !important; }
+  h2 { font-size: 0.75rem !important; }
+}


### PR DESCRIPTION
## Summary
- **Retro CRT aesthetic**: Phosphor green-on-black color palette, CRT scanline overlay, subtle screen flicker, pixel fonts (Press Start 2P for headings, IBM Plex Mono for body)
- **Matrix rain intro**: Binary rain animation on home page (~2.5s, click to skip, session-cached so it only plays once per visit)
- **Retro landing page**: Terminal-style nav grid (`about.exe`, `resume.dat`, `blog.log`), social links bar, system info footer
- **Fixes**: Geo meta tags corrected from Mumbai to Massachusetts, baseof.html override removes Tailwind body classes

## Files changed
| File | Action |
|------|--------|
| `static/css/custom.css` | New — all theme overrides |
| `layouts/partials/head.html` | Updated — fonts, custom CSS, geo fix |
| `layouts/_default/baseof.html` | New — CRT container override |
| `layouts/_default/home.html` | Replaced — matrix rain + retro landing |

## Test plan
- [ ] Verify matrix rain plays on first visit, skips on refresh
- [ ] Click-to-skip works during animation
- [ ] All nav links resolve correctly (about, resume, blog)
- [ ] Phosphor green theme applies across all pages
- [ ] Mobile responsive — check at 375px width
- [ ] Fonts load (IBM Plex Mono body, Press Start 2P headings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)