### PR TITLE
Remove sys/loc/stack footer from home page

### DIFF
--- a/layouts/_default/home.html
+++ b/layouts/_default/home.html
@@ -37,14 +37,6 @@
       <a href="https://www.linkedin.com/in/patrick-nelson-1b41561b6/" target="_blank">[linkedin]</a>
     </div>
 
-    <p class="home-footer-text">
-      <span class="muted">sys:</span> Senior DevOps Engineer | AI-Augmented SRE
-      <br>
-      <span class="muted">loc:</span> Massachusetts
-      <br>
-      <span class="muted">stack:</span> Go / Python / Azure / Kubernetes / Terraform
-    </p>
-
   </main>
 
 <script>


### PR DESCRIPTION
## Summary
- Removes the sys/loc/stack info block from the bottom of the home page for a cleaner landing

## Test plan
- [ ] Home page renders without the footer text
- [ ] Matrix rain and nav grid unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)