### PR TITLE
Fix CI build: override third_party_js partial, bump Hugo

### DIFF
--- a/.github/workflows/hugo-build.yaml
+++ b/.github/workflows/hugo-build.yaml
@@ -32,7 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.145.0
+      HUGO_VERSION: 0.160.1
       HUGO_ENVIRONMENT: production
       TZ: America/New_York
     steps:

--- a/layouts/partials/third_party_js.html
+++ b/layouts/partials/third_party_js.html
@@ -1,0 +1,1 @@
+{{/* Override: no third-party JS */}}


### PR DESCRIPTION
## Summary
- Replace the empty `third_party_js/.gitkeep` directory with a no-op `third_party_js.html` partial override — the theme's `readDir` was finding `.gitkeep` and trying to load it as a Hugo template
- Bump Hugo from 0.145.0 to 0.160.1 to match local dev version

## Test plan
- [ ] CI build passes
- [ ] Site renders correctly after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)