### PR TITLE
Fix mobile menu background to match terminal theme

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -16,7 +16,7 @@
     </div>
   {{ end }}
 
-  <div class="dropdown-menu flex flex-row absolute max-lg:w-full max-lg:items-center max-lg:justify-center max-lg:-top-full lg:static max-lg:bg-slate-900 max-lg:h-[calc(100dvh)] max-lg:left-0">
+  <div class="dropdown-menu flex flex-row absolute max-lg:w-full max-lg:items-center max-lg:justify-center max-lg:-top-full lg:static max-lg:bg-[#0a0a0a] max-lg:h-[calc(100dvh)] max-lg:left-0">
     <ul class="flex flex-col lg:flex-row gap-2">
       {{ partial "default_menu.html" . }}
     </ul>


### PR DESCRIPTION
## Summary
- Replace `bg-slate-900` with terminal black `#0a0a0a` on the mobile dropdown menu so it matches the site's retro terminal theme instead of showing blue-gray

## Test plan
- [ ] Open site on mobile (or responsive mode) and tap the hamburger menu
- [ ] Menu background should be black, not blue-gray

🤖 Generated with [Claude Code](https://claude.com/claude-code)