### PR TITLE
Fix mobile dropdown menu background and z-index

### DIFF
--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -140,6 +140,16 @@ nav a:hover, .menu a:hover, header a:hover {
   text-shadow: 0 0 8px var(--terminal-amber);
 }
 
+/* --- Mobile Dropdown Menu --- */
+/* Tailwind's compiled CSS lacks the arbitrary bg-[#0a0a0a] class,
+   so we apply terminal-black and z-index here instead. */
+@media not all and (min-width: 1024px) {
+  .dropdown-menu {
+    background-color: var(--terminal-bg) !important;
+    z-index: 40;
+  }
+}
+
 /* --- Code Blocks --- */
 pre, code {
   background-color: #111 !important;


### PR DESCRIPTION
## Summary
- The compiled Tailwind CSS lacks the arbitrary `bg-[#0a0a0a]` utility class used in `menu.html`, leaving the mobile menu overlay **transparent** when opened
- Adds a CSS override in `custom.css` applying `background-color: var(--terminal-bg)` and `z-index: 40` to `.dropdown-menu` below the `lg` breakpoint
- Verified consistent terminal-black background across `/resume/`, `/about.html`, and `/blog/` at 375px viewport

## Test plan
- [ ] Open site on mobile (375px viewport) or resize browser below 1024px
- [ ] Tap hamburger menu on Resume, About, and Blog pages
- [ ] Confirm dropdown has solid `#0a0a0a` terminal-black background (not transparent or slate-900 blue-gray)
- [ ] Confirm menu covers page content (z-index) and close button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)